### PR TITLE
Automatic deploy for develop branch

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,70 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: latest-dev
+      BUILD_NUMBER: ${{ github.run_number }}
+      ECR_REGISTRY: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com
+      ECR_REPOSITORY: sso/waffle-account-server
+      S3_BUCKET_NAME: waffle-account-server-build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Upload Dockerrun.aws.json to S3
+        run: |
+          mv Dockerrun-dev.aws.json Dockerrun.aws.json
+          zip deploy-dev.zip Dockerrun.aws.json
+          aws s3 cp deploy-dev.zip s3://$S3_BUCKET_NAME/deploy-dev.zip
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker Build, tag, and push image to ECR
+        id: build-image
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Delete untagged images in ECR
+        run: |
+          UNTAGGED_IMAGES=$( aws ecr list-images --repository-name $ECR_REPOSITORY --filter "tagStatus=UNTAGGED" --query 'imageIds[*]' --output json )
+          aws ecr batch-delete-image --repository-name $ECR_REPOSITORY --image-ids "$UNTAGGED_IMAGES" || true
+
+      - name: Deploy to ElasticBeanstalk
+        run: |
+          aws elasticbeanstalk create-application-version \
+            --application-name waffle-account-server \
+            --version-label dev-$BUILD_NUMBER \
+            --description dev-$BUILD_NUMBER \
+            --source-bundle S3Bucket=$S3_BUCKET_NAME,S3Key='deploy-dev.zip'
+          aws elasticbeanstalk update-environment \
+            --environment-name waffle-account-server-dev \
+            --version-label dev-$BUILD_NUMBER
+
+      - name: Slack Notify
+        uses: rtCamp/action-slack-notify@v2.1.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: NEW RELEASE
+          SLACK_USERNAME: waffle-account-server-dev
+          SLACK_ICON: https://user-images.githubusercontent.com/35535636/158051666-322decf3-c7d9-414d-a9bd-ec172054ab96.png
+          SLACK_MESSAGE: Check <https://ap-northeast-2.console.aws.amazon.com/elasticbeanstalk/home?region=ap-northeast-2#/environment/dashboard?applicationName=waffle-account-server&environmentId=e-pcafnzntsp|EB> for updated environment
+          SLACK_FOOTER: http://account-api-dev.wafflestudio.com

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, feature/deploy ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ develop, feature/deploy ]
+    branches: [ develop ]
 
 jobs:
   deploy:
@@ -63,6 +63,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.1.2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: team-sso
           SLACK_TITLE: NEW RELEASE
           SLACK_USERNAME: waffle-account-server-dev
           SLACK_ICON: https://user-images.githubusercontent.com/35535636/158051666-322decf3-c7d9-414d-a9bd-ec172054ab96.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jdk-slim
+WORKDIR /app
+COPY . /app
+RUN ./gradlew bootJar
+EXPOSE 8080
+CMD java $JAVA_OPTS -jar build/libs/account-0.0.1.jar

--- a/Dockerrun-dev.aws.json
+++ b/Dockerrun-dev.aws.json
@@ -1,0 +1,14 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Logging": "/tmp/waffle-account-server",
+  "Image": {
+    "Name": "405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/sso/waffle-account-server:latest-dev",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": 8080,
+      "HostPort": 80
+    }
+  ]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.wafflestudio"
-version = "0.0.1-SNAPSHOT"
+version = "0.0.1"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {


### PR DESCRIPTION
# Major Changes
## 1. Using GitHub Actions for Automatic Deployment
- Docker, AWS ECR, AWS S3 등을 이용하여 AWS [EB 환경](https://ap-northeast-2.console.aws.amazon.com/elasticbeanstalk/home?region=ap-northeast-2#/environment/dashboard?applicationName=waffle-account-server&environmentId=e-pcafnzntsp)에 자동 배포
- develop branch 에 merge(push) 하면 http://account-api-dev.wafflestudio.com 에 배포됨
  - **HTTPS 가 현재 안 되는 것은 EB 에서의 비용 절감을 위해 load balancer 가 필요 없는 single instance 환경을 활용했기 때문인데, 이 설정에서도 HTTPS 되도록 하는 게 가능하긴 합니다. 다만 일단 번거로워서 이번엔 스킵합니다.**
- EB 환경 관리 url인 https://ap-northeast-2.console.aws.amazon.com/elasticbeanstalk/home?region=ap-northeast-2#/environment/dashboard?applicationName=waffle-account-server&environmentId=e-pcafnzntsp 에서 확인 가능
- 현재로서는 사실 GitHub Actions가 성공한다고 해서 반드시 EB 배포(환경 update)가 성공한 것은 아님. Docker build 후 EB의 환경 update를 트리거시켜주는 것까지 성공하면 GitHub Actions는 성공이고 바로 Slack으로 메시지를 보냄. 추후 개선 예정.

* * *

FYI. Jenkins를 사용하는 것은 아니지만, AWS ECR, AWS S3를 이용하여 AWS EB에 배포한다는 점에서 아래 글과 아이디어가 같기에 첨부합니다.

https://mygumi.tistory.com/378

글에도 있는 이 이미지에서 Jenins를 GitHub Actions로만 바꿔주면 됨.
참고로 이 글에서는 EB 환경을 Multicontainer Docker 플랫폼 방식으로 이용하고 있는데, 우린 그건 아니고 그냥 단일 container docker 플랫폼입니다.(그냥 jar 하나만 돌리고 앞에 Nginx만 꽂아주면 되므로)

![R1280x0-7](https://user-images.githubusercontent.com/35535636/103189864-052ce780-4912-11eb-8b1b-f52e2d42c70d.png)

매번 빌드를 할 때마다 이전 docker image는 ECR에서 착실히 지우도록 스크립트를 만들어놓았습니다.

CI/CD를 위한 AWS IAM 계정 sso-cicd([관련 thread](https://wafflestudio.slack.com/archives/C01M4TMNFPX/p1647085852555949?thread_ts=1647085661.858389&cid=C01M4TMNFPX))를 만들어서 그것을 GitHub Actions가 이용하도록 했습니다.