### PR TITLE
Unregister API & Security Config for Converting AccessToken to UserId

### DIFF
--- a/src/main/kotlin/com/wafflestudio/account/api/domain/account/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/domain/account/RefreshTokenRepository.kt
@@ -1,9 +1,16 @@
 package com.wafflestudio.account.api.domain.account
 
+import org.springframework.data.r2dbc.repository.Modifying
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface RefreshTokenRepository : CoroutineCrudRepository<RefreshToken, Long> {
     suspend fun findByToken(token: String): RefreshToken?
+
+    @Modifying
+    @Query("UPDATE account_refresh_token SET expire_at = :expire_at WHERE user_id = :userId")
+    suspend fun updateExpireAtByUserId(userId: Long, expireAt: LocalDateTime)
 }

--- a/src/main/kotlin/com/wafflestudio/account/api/domain/account/User.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/domain/account/User.kt
@@ -15,13 +15,13 @@ class User(
 
     val password: String? = null,
 
-    val isActive: Boolean = true,
+    var isActive: Boolean = true,
 
-    val isBanned: Boolean = false,
+    var isBanned: Boolean = false,
 
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
 
     val provider: AuthProvider = AuthProvider.LOCAL
 )

--- a/src/main/kotlin/com/wafflestudio/account/api/error/AccountException.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/error/AccountException.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.account.api.error
 
-open class AccountException(val errorType: ErrorType): RuntimeException(errorType.name)
+open class AccountException(val errorType: ErrorType) : RuntimeException(errorType.name)
 
 object UserInactiveException : AccountException(ErrorType.USER_INACTIVE)
 object EmailAlreadyExistsException : AccountException(ErrorType.EMAIL_ALREADY_EXISTS)

--- a/src/main/kotlin/com/wafflestudio/account/api/error/AccountException.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/error/AccountException.kt
@@ -1,9 +1,9 @@
 package com.wafflestudio.account.api.error
 
-open class AccountException(val errorType: ErrorType) : RuntimeException(errorType.name)
+open class AccountException(val errorType: ErrorType): RuntimeException(errorType.name)
 
-object UserInactiveException : AccountException(ErrorType.USER_INACTIVE)
-object EmailAlreadyExistsException : AccountException(ErrorType.EMAIL_ALREADY_EXISTS)
-object UserDoesNotExistsException : AccountException(ErrorType.USER_NOT_FOUND)
-object WrongPasswordException : AccountException(ErrorType.WRONG_PASSWORD)
-object TokenInvalidException : AccountException(ErrorType.INVALID_TOKEN)
+object UserInactiveException: AccountException(ErrorType.USER_INACTIVE)
+object EmailAlreadyExistsException: AccountException(ErrorType.EMAIL_ALREADY_EXISTS)
+object UserDoesNotExistsException: AccountException(ErrorType.USER_NOT_FOUND)
+object WrongPasswordException: AccountException(ErrorType.WRONG_PASSWORD)
+object TokenInvalidException: AccountException(ErrorType.INVALID_TOKEN)

--- a/src/main/kotlin/com/wafflestudio/account/api/error/AccountException.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/error/AccountException.kt
@@ -2,8 +2,8 @@ package com.wafflestudio.account.api.error
 
 open class AccountException(val errorType: ErrorType): RuntimeException(errorType.name)
 
-object UserInactiveException: AccountException(ErrorType.USER_INACTIVE)
-object EmailAlreadyExistsException: AccountException(ErrorType.EMAIL_ALREADY_EXISTS)
-object UserDoesNotExistsException: AccountException(ErrorType.USER_NOT_FOUND)
-object WrongPasswordException: AccountException(ErrorType.WRONG_PASSWORD)
-object TokenInvalidException: AccountException(ErrorType.INVALID_TOKEN)
+object UserInactiveException : AccountException(ErrorType.USER_INACTIVE)
+object EmailAlreadyExistsException : AccountException(ErrorType.EMAIL_ALREADY_EXISTS)
+object UserDoesNotExistsException : AccountException(ErrorType.USER_NOT_FOUND)
+object WrongPasswordException : AccountException(ErrorType.WRONG_PASSWORD)
+object TokenInvalidException : AccountException(ErrorType.INVALID_TOKEN)

--- a/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.account.api.interfaces.auth
 
+import com.wafflestudio.account.api.security.CurrentUser
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -26,11 +27,10 @@ class AuthController(
     }
 
     @DeleteMapping("/v1/users/me")
-    suspend fun unregister() {
-        val userId: Long = 1
+    suspend fun unregister(currentUser: CurrentUser): UnregisterResponse {
+        val userId = currentUser.id
         return authService.unregister(userId)
     }
-
 
     @PutMapping("/v1/validate")
     suspend fun tokenValidate(

--- a/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.account.api.interfaces.auth
 
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -23,6 +24,13 @@ class AuthController(
     ): TokenResponse {
         return authService.signin(signinRequest)
     }
+
+    @DeleteMapping("/v1/users/me")
+    suspend fun unregister() {
+        val userId: Long = 1
+        return authService.unregister(userId)
+    }
+
 
     @PutMapping("/v1/validate")
     suspend fun tokenValidate(

--- a/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthRequest.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.account.api.interfaces.auth
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
@@ -16,10 +17,12 @@ data class LocalAuthRequest(
 
 data class ValidateRequest(
     @field:NotBlank
+    @JsonProperty("access_token")
     val accessToken: String,
 )
 
 data class RefreshRequest(
     @field:NotBlank
+    @JsonProperty("refresh_token")
     val refreshToken: String,
 )

--- a/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthResponse.kt
@@ -14,3 +14,7 @@ data class RefreshResponse(
     @JsonProperty("access_token")
     val accessToken: String,
 )
+
+data class UnregisterResponse(
+    val unregistered: Boolean
+)

--- a/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/interfaces/auth/AuthService.kt
@@ -150,4 +150,15 @@ class AuthService(
             refreshToken = refreshToken,
         )
     }
+
+    suspend fun unregister(userId: Long) {
+        val user = userRepository.findById(userId) ?: throw UserDoesNotExistsException
+        if (!checkUnregistrable(user)) {
+
+        }
+    }
+
+    private suspend fun checkUnregistrable(user: User): Boolean {
+        return true
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/account/api/security/CurrentUser.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/CurrentUser.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.account.api.security
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+data class CurrentUser(
+    var id: Long = 0,
+    val token: String,
+) : Authentication {
+    override fun getName() = id.toString()
+    override fun getAuthorities() = listOf(SimpleGrantedAuthority(""))
+    override fun getCredentials() {}
+    override fun getDetails() {}
+    override fun getPrincipal() {}
+    override fun isAuthenticated() = true
+    override fun setAuthenticated(isAuthenticated: Boolean) {}
+}

--- a/src/main/kotlin/com/wafflestudio/account/api/security/JwtAccessTokenVerifier.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/JwtAccessTokenVerifier.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.account.api.security
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAccessTokenVerifier(
+    @Value("\${auth.jwt.access.privateKey}") private val accessKey: String,
+    @Value("\${auth.jwt.issuer}") private val issuer: String,
+) {
+    private val jwtParser = Jwts.parserBuilder()
+        .setSigningKey(Keys.hmacShaKeyFor(accessKey.toByteArray()))
+        .requireIssuer(issuer)
+        .build()
+
+    fun getUserId(token: String): Long? {
+        return try {
+            val claims = jwtParser.parseClaimsJws(token).body
+            claims["sub"].toString().toLong()
+        } catch (e: Exception) {
+            print("error! $e")
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/account/api/security/JwtAccessTokenVerifier.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/JwtAccessTokenVerifier.kt
@@ -20,7 +20,6 @@ class JwtAccessTokenVerifier(
             val claims = jwtParser.parseClaimsJws(token).body
             claims["sub"].toString().toLong()
         } catch (e: Exception) {
-            print("error! $e")
             return null
         }
     }

--- a/src/main/kotlin/com/wafflestudio/account/api/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/SecurityConfig.kt
@@ -1,25 +1,34 @@
-package com.wafflestudio.account.api.config
+package com.wafflestudio.account.api.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authentication.AuthenticationWebFilter
 
 @EnableWebFluxSecurity
 class SecurityConfig {
     @Bean
     fun securityWebFilterChain(
         http: ServerHttpSecurity,
+        tokenAuthenticationConverter: TokenAuthenticationConverter,
+        tokenAuthenticationManager: TokenAuthenticationManager,
     ): SecurityWebFilterChain {
+        // api gateway 가 jwt access token 을 user id 로 바꾸어 보내주기 전까지는, account 서버가 이를 직접 처리
+        val authenticationWebFilter = AuthenticationWebFilter(tokenAuthenticationManager)
+        authenticationWebFilter.setServerAuthenticationConverter(tokenAuthenticationConverter)
+
         return http.authorizeExchange()
             .pathMatchers("/health_check").permitAll()
             .pathMatchers(HttpMethod.POST, "/v1/auth/signin").permitAll()
             .pathMatchers(HttpMethod.POST, "/v1/users").permitAll()
             .pathMatchers("/v1/**").authenticated()
             .and()
+            .addFilterAt(authenticationWebFilter, SecurityWebFiltersOrder.AUTHENTICATION)
             .csrf().disable()
             .build()
     }

--- a/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationConverter.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationConverter.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.account.api.security
+
+import kotlinx.coroutines.reactor.mono
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@Component
+class TokenAuthenticationConverter: ServerAuthenticationConverter {
+    private val authorization = "authorization"
+    private val authorizationBearerPrefix = "Bearer "
+
+    override fun convert(exchange: ServerWebExchange?): Mono<Authentication> = mono {
+        val authorization = exchange?.getHeader(authorization) ?: return@mono null
+        val token = authorization.removePrefix(authorizationBearerPrefix)
+
+        return@mono CurrentUser(
+            token = token,
+        )
+    }
+
+    private fun ServerWebExchange.getHeader(headerName: String): String? {
+        return request.headers.getFirst(headerName)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationConverter.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationConverter.kt
@@ -9,11 +9,11 @@ import reactor.core.publisher.Mono
 
 @Component
 class TokenAuthenticationConverter : ServerAuthenticationConverter {
-    private val authorization = "authorization"
+    private val authorizationHeader = "authorization"
     private val authorizationBearerPrefix = "Bearer "
 
     override fun convert(exchange: ServerWebExchange?): Mono<Authentication> = mono {
-        val authorization = exchange?.getHeader(authorization) ?: return@mono null
+        val authorization = exchange?.getHeader(authorizationHeader) ?: return@mono null
         val token = authorization.removePrefix(authorizationBearerPrefix)
 
         return@mono CurrentUser(

--- a/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationConverter.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationConverter.kt
@@ -8,7 +8,7 @@ import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 
 @Component
-class TokenAuthenticationConverter: ServerAuthenticationConverter {
+class TokenAuthenticationConverter : ServerAuthenticationConverter {
     private val authorization = "authorization"
     private val authorizationBearerPrefix = "Bearer "
 

--- a/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationManager.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationManager.kt
@@ -10,11 +10,11 @@ import reactor.core.publisher.Mono
 @Component
 class TokenAuthenticationManager(
     private val jwtAccessTokenVerifier: JwtAccessTokenVerifier,
-): ReactiveAuthenticationManager {
+) : ReactiveAuthenticationManager {
     override fun authenticate(authentication: Authentication): Mono<Authentication> = mono {
         authentication as CurrentUser
 
-        val userId =  jwtAccessTokenVerifier.getUserId(authentication.token) ?: throw BadCredentialsException("")
+        val userId = jwtAccessTokenVerifier.getUserId(authentication.token) ?: throw BadCredentialsException("")
         authentication.id = userId
         authentication
     }

--- a/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationManager.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/security/TokenAuthenticationManager.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.account.api.security
+
+import kotlinx.coroutines.reactor.mono
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.authentication.ReactiveAuthenticationManager
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class TokenAuthenticationManager(
+    private val jwtAccessTokenVerifier: JwtAccessTokenVerifier,
+): ReactiveAuthenticationManager {
+    override fun authenticate(authentication: Authentication): Mono<Authentication> = mono {
+        authentication as CurrentUser
+
+        val userId =  jwtAccessTokenVerifier.getUserId(authentication.token) ?: throw BadCredentialsException("")
+        authentication.id = userId
+        authentication
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-spring.profiles.default: dev
-
 spring:
   r2dbc:
     url: r2dbc:mysql://localhost:3306/waffle_account?useUnicode=true&characterEncoding=utf8&serverTimezone=UTC


### PR DESCRIPTION
related slack: https://wafflestudio.slack.com/archives/C031NAX51P0/p1651888216015769

# Major Changes
## 1. `DELETE /v1/users/me`를 통한 회원 탈퇴 API 구현
- 일단 아래 내용만 구현함
  - User 의 is_active 를 false 로 변경하고 updated_at 을 회원 탈퇴 시점으로 변경
  - 해당 유저의 RefreshToken 의 expire_at 을 회원 탈퇴 시점으로 변경

## 2. Authorization 헤더의 Jwt access token 을 user id 로 변환하는 기능 지원
- 상의된 바에 따라, **API gateway 가 jwt access token 을 user id 로 바꾸어 보내주기 전까지는, account 서버가 이를 직접 처리합니다.**

- SecurityConfig 에서 `permitAll()` 별도로 되어있지 않은 endpoint 에 대해서는, 적절한 access token 이 `Authorization` 헤더에 `Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2FjY291bnQtYXBpLWxvY2FsLndhZmZsZXN0dWRpby5jb20iLCJzdWIiOiIxMCIsImlhdCI6MTY1MTg5NTkyNiwiZXhwIjoxNjUxOTgyMzI2fQ.IRt7_ME1GTEH0rcOVeLqyHCBBpX4eHyqiInVVagMF0U` 같은 식으로 들어오지 않는 이상 401 반환
  - 현재 PUT /v1/validate, PUT /v1/refresh endpoint 도 별도 permitAll() 안 되어있어서, Authorization 헤더 세팅되어있지 않은 요청이면 401 반환됩니다. 이 점 참고해주세요. @chosanglyul 

- **적절한 Authorization 헤더로 요청이 들어오면, controller 의 param 으로 `CurrentUser`으로 받으면, 그 내부의 id 를 통해서 user id 를 이용할 수 있습니다.**
