### PR TITLE
Add codeowners and gitattributes

### DIFF
--- a/.github/.gitattributes
+++ b/.github/.gitattributes
@@ -1,0 +1,1 @@
+src/main/resources/static/docs/** linguist-vendored

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @subeenpark-io @davin111 @chosanglyul @Hank-Choi


### PR DESCRIPTION
### 1. CODEOWNERS 를 통해 review 프로세스 강화. CODEOWNERS 의 리뷰가 2개 이상 필요하도록 develop branch protection rule 에 적용할 것.
  - 한글 이름 가나다 순으로 넣음. 추후 repo contribute 비중에 따라 순서 조절할 수도.

### 2. HTML 을 repo language stats 에서 제외하기 위해 gitattributes 파일 추가
  - https://github.com/github/linguist/blob/master/docs/overrides.md#vendored-code 참고
