### PR TITLE
[NOT COMPLETED] Apple Social Connect

### DIFF
--- a/src/main/kotlin/com/wafflestudio/account/api/client/AppleClient.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/AppleClient.kt
@@ -1,46 +1,64 @@
 package com.wafflestudio.account.api.client
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.nimbusds.jwt.SignedJWT
 import com.wafflestudio.account.api.domain.account.enum.SocialProvider
 import com.wafflestudio.account.api.interfaces.auth.OAuth2RequestWithAuthCode
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import java.security.KeyFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.sql.Timestamp
+import java.time.LocalDateTime
+import java.util.Base64
 
-@Component("GOOGLE")
-class GoogleClient(
+@Component("APPLE")
+class AppleClient(
     private val webClientHelper: WebClientHelper,
     clientRegistrationRepository: ReactiveClientRegistrationRepository,
+    @Value("\${spring.security.oauth2.client.registration.apple.key-id}") private val keyId: String,
+    @Value("\${spring.security.oauth2.client.registration.apple.private-key}") privateKeyString: String,
+    @Value("\${spring.security.oauth2.client.registration.apple.team-id}") private val teamId: String,
 ) : OAuth2Client {
 
     private val webClient = webClientHelper.buildWebClient()
     private val clientRegistration = clientRegistrationRepository.findByRegistrationId(
-        SocialProvider.GOOGLE.value
+        SocialProvider.APPLE.value
     ).block()!!
 
+    private final val decoder = Base64.getDecoder()
+    private final val factory = KeyFactory.getInstance("EC")
+    private final val privateKey = factory.generatePrivate(PKCS8EncodedKeySpec(decoder.decode(privateKeyString)))
+
+    private fun buildJwt(): String {
+        val jwt = Jwts.builder()
+            .setHeaderParam("kid", keyId)
+            .setIssuer(teamId)
+            .setSubject(clientRegistration.clientId)
+            .setAudience("https://appleid.apple.com")
+            .setIssuedAt(Timestamp.valueOf(LocalDateTime.now()))
+            .setExpiration(Timestamp.valueOf(LocalDateTime.now().plusDays(1)))
+            .signWith(privateKey, SignatureAlgorithm.ES256)
+            .compact()
+
+        println("jwt: $jwt")
+        return jwt
+    }
+
     override suspend fun getMe(token: String): OAuth2UserResponse? {
-        return webClient
-            .get()
-            .uri(clientRegistration.providerDetails.userInfoEndpoint.uri)
-            .headers {
-                it.setBearerAuth(token)
-            }
-            .retrieve()
-            .bodyToMono<GoogleOAuth2UserResponse>()
-            .onErrorResume {
-                WebClientHelper.logger.error(it.message, it)
-                Mono.empty()
-            }
-            .map {
-                OAuth2UserResponse(
-                    socialId = it.sub,
-                    email = it.email,
-                )
-            }
-            .awaitSingleOrNull()
+        return SignedJWT.parse(token).jwtClaimsSet.getStringListClaim("email").firstOrNull()?.let {
+            OAuth2UserResponse(
+                socialId = it,
+                email = it,
+            )
+        }
     }
 
     override suspend fun getMeWithAuthCode(
@@ -55,35 +73,36 @@ class GoogleClient(
                     mapOf(
                         "grant_type" to "authorization_code",
                         "client_id" to clientRegistration.clientId,
-                        "client_secret" to clientRegistration.clientSecret,
+                        "client_secret" to buildJwt(),
                         "redirect_uri" to oAuth2RequestWithAuthCode.redirectUri,
                         "code" to oAuth2RequestWithAuthCode.authorizationCode,
                     )
                 )
             )
             .retrieve()
-            .bodyToMono<GoogleOAuth2TokenResponse>()
+            .bodyToMono<AppleOAuth2TokenResponse>()
             .onErrorResume {
                 WebClientHelper.logger.error(it.message, it)
                 Mono.empty()
             }.awaitSingleOrNull()
 
         return tokenResponse?.let {
-            getMe(it.accessToken)
+            getMe(it.idToken)
         }
     }
 }
 
-data class GoogleOAuth2TokenResponse(
+data class AppleOAuth2TokenResponse(
     @JsonProperty("token_type")
-    val tokenType: String?,
+    val tokenType: String,
     @JsonProperty("access_token")
     val accessToken: String,
     @JsonProperty("expires_in")
-    val expiresIn: Int?,
+    val expiresIn: Int,
     @JsonProperty("refresh_token")
-    val refreshToken: String?,
-    @JsonProperty("refresh_token_expires_in")
-    val refreshTokenExpiresIn: Int?,
-    val scope: String?,
+    val refreshToken: String,
+    @JsonProperty("id_token")
+    val idToken: String,
+    @JsonProperty("user")
+    val user: AppleOAuth2UserResponse,
 )

--- a/src/main/kotlin/com/wafflestudio/account/api/client/AppleClient.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/AppleClient.kt
@@ -38,7 +38,7 @@ class AppleClient(
     private final val privateKey = factory.generatePrivate(PKCS8EncodedKeySpec(decoder.decode(privateKeyString)))
 
     private fun buildJwt(): String {
-        val jwt = Jwts.builder()
+        return Jwts.builder()
             .setHeaderParam("kid", keyId)
             .setIssuer(teamId)
             .setSubject(clientRegistration.clientId)
@@ -47,9 +47,6 @@ class AppleClient(
             .setExpiration(Timestamp.valueOf(LocalDateTime.now().plusDays(1)))
             .signWith(privateKey, SignatureAlgorithm.ES256)
             .compact()
-
-        println("jwt: $jwt")
-        return jwt
     }
 
     override suspend fun getMe(token: String): OAuth2UserResponse? {

--- a/src/main/kotlin/com/wafflestudio/account/api/client/GithubClient.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/GithubClient.kt
@@ -21,14 +21,12 @@ class GithubClient(
         SocialProvider.GITHUB.value
     ).block()!!
 
-    override suspend fun getMe(
-        accessToken: String
-    ): OAuth2UserResponse? {
+    override suspend fun getMe(token: String): OAuth2UserResponse? {
         return webClient
             .get()
             .uri(clientRegistration.providerDetails.userInfoEndpoint.uri)
             .headers {
-                it.setBearerAuth(accessToken)
+                it.setBearerAuth(token)
             }
             .retrieve()
             .bodyToMono<GithubOAuth2UserResponse>()

--- a/src/main/kotlin/com/wafflestudio/account/api/client/KakaoClient.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/KakaoClient.kt
@@ -21,14 +21,12 @@ class KakaoClient(
         SocialProvider.KAKAO.value
     ).block()!!
 
-    override suspend fun getMe(
-        accessToken: String
-    ): OAuth2UserResponse? {
+    override suspend fun getMe(token: String): OAuth2UserResponse? {
         return webClient
             .get()
             .uri(clientRegistration.providerDetails.userInfoEndpoint.uri)
             .headers {
-                it.setBearerAuth(accessToken)
+                it.setBearerAuth(token)
             }
             .retrieve()
             .bodyToMono<KakaoOAuth2UserResponse>()

--- a/src/main/kotlin/com/wafflestudio/account/api/client/NaverClient.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/NaverClient.kt
@@ -21,14 +21,12 @@ class NaverClient(
         SocialProvider.NAVER.value
     ).block()!!
 
-    override suspend fun getMe(
-        accessToken: String
-    ): OAuth2UserResponse? {
+    override suspend fun getMe(token: String): OAuth2UserResponse? {
         return webClient
             .get()
             .uri(clientRegistration.providerDetails.userInfoEndpoint.uri)
             .headers {
-                it.setBearerAuth(accessToken)
+                it.setBearerAuth(token)
             }
             .retrieve()
             .bodyToMono<NaverOAuth2UserResponse>()

--- a/src/main/kotlin/com/wafflestudio/account/api/client/OAuth2Client.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/OAuth2Client.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.account.api.client
 import com.wafflestudio.account.api.interfaces.auth.OAuth2RequestWithAuthCode
 
 interface OAuth2Client {
-    suspend fun getMe(accessToken: String): OAuth2UserResponse?
+    suspend fun getMe(token: String): OAuth2UserResponse?
 
     suspend fun getMeWithAuthCode(oAuth2RequestWithAuthCode: OAuth2RequestWithAuthCode): OAuth2UserResponse?
 }

--- a/src/main/kotlin/com/wafflestudio/account/api/client/OAuth2UserResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/client/OAuth2UserResponse.kt
@@ -37,3 +37,8 @@ data class GithubOAuth2UserResponse(
     val id: Long,
     val email: String,
 )
+
+data class AppleOAuth2UserResponse(
+    val sub: String,
+    val email: String,
+)

--- a/src/main/kotlin/com/wafflestudio/account/api/domain/account/enum/SocialProvider.kt
+++ b/src/main/kotlin/com/wafflestudio/account/api/domain/account/enum/SocialProvider.kt
@@ -6,6 +6,7 @@ enum class SocialProvider(val value: String) {
     NAVER("naver"),
     KAKAO("kakao"),
     GITHUB("github"),
+    APPLE("apple"),
     ;
 
     companion object {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,9 +54,6 @@ spring:
             token-uri: https://appleid.apple.com/auth/token
             user-info-uri: https://appleid.apple.com/auth/authorize
             user-name-attribute: sub
-            key-id:
-            private-key:
-            team-id:
 auth:
   jwt:
     issuer: https://account-api-local.wafflestudio.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,19 +21,23 @@ spring:
             client-secret:
             client-name: kakao
             scope: account_email
-            redirect-uri: https://sso-dev.wafflestudio.com/oauth/callback/kakao
+            redirect-uri: https://sso.wafflestudio.com/oauth/callback/kakao.html
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
           naver:
             client-id:
             client-secret:
             client-name: naver
-            redirect-uri: https://sso-dev.wafflestudio.com/oauth/callback/naver
+            redirect-uri: https://sso.wafflestudio.com/oauth/callback/naver.html
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
           github:
             client-id:
             client-secret:
+          apple:
+            client-id:
+            redirect-uri: https://sso.wafflestudio.com/oauth/callback/apple.html
+            authorization-grant-type: authorization_code
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -45,7 +49,14 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
-
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize
+            token-uri: https://appleid.apple.com/auth/token
+            user-info-uri: https://appleid.apple.com/auth/authorize
+            user-name-attribute: sub
+            key-id:
+            private-key:
+            team-id:
 auth:
   jwt:
     issuer: https://account-api-local.wafflestudio.com
@@ -87,7 +98,8 @@ spring:
           github:
             client-id: fake-client-id
             client-secret: fake-client-secret
-
+          apple:
+            client-id: fake-client-id
 ---
 
 spring.config.activate.on-profile: dev

--- a/src/test/kotlin/com/wafflestudio/account/AuthTest.kt
+++ b/src/test/kotlin/com/wafflestudio/account/AuthTest.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.account
 
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.account.api.client.AppleClient
 import com.wafflestudio.account.api.error.ErrorHandler
 import com.wafflestudio.account.api.interfaces.auth.AuthController
 import com.wafflestudio.account.api.interfaces.auth.LocalAuthRequest
@@ -196,4 +198,7 @@ class AuthTest(val authController: AuthController) : WordSpec({
             )
         }
     }
-})
+}) {
+    @MockkBean
+    private lateinit var appleClient: AppleClient
+}

--- a/src/test/kotlin/com/wafflestudio/account/SampleTest.kt
+++ b/src/test/kotlin/com/wafflestudio/account/SampleTest.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.account
 
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.account.api.client.AppleClient
 import com.wafflestudio.account.api.interfaces.health.HealthCheckController
 import io.kotest.core.spec.style.WordSpec
 import org.springframework.boot.test.context.SpringBootTest
@@ -38,4 +40,7 @@ class SampleTest(val healthCheckController: HealthCheckController) : WordSpec({
             )
         }
     }
-})
+}) {
+    @MockkBean
+    private lateinit var appleClient: AppleClient
+}

--- a/src/test/kotlin/com/wafflestudio/account/UserInfoTest.kt
+++ b/src/test/kotlin/com/wafflestudio/account/UserInfoTest.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.account
 
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.account.api.client.AppleClient
 import com.wafflestudio.account.api.domain.account.User
 import com.wafflestudio.account.api.domain.account.UserRepository
 import com.wafflestudio.account.api.domain.account.enum.SocialProvider
@@ -146,4 +148,7 @@ class UserInfoTest(val userInfoController: UserInfoController, val userRepositor
             )
         }
     }
-})
+}) {
+    @MockkBean
+    private lateinit var appleClient: AppleClient
+}

--- a/src/test/kotlin/com/wafflestudio/account/UsersTest.kt
+++ b/src/test/kotlin/com/wafflestudio/account/UsersTest.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.account
 
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.account.api.client.AppleClient
 import com.wafflestudio.account.api.error.ErrorHandler
 import com.wafflestudio.account.api.interfaces.auth.AuthController
 import com.wafflestudio.account.api.interfaces.auth.LocalAuthRequest
@@ -175,4 +177,7 @@ class UsersTest(val authController: AuthController) : WordSpec({
             )
         }
     }
-})
+}) {
+    @MockkBean
+    private lateinit var appleClient: AppleClient
+}

--- a/src/test/kotlin/com/wafflestudio/account/interfaces/auth/SocialAuthServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/account/interfaces/auth/SocialAuthServiceTest.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.account.interfaces.auth
 
 import com.ninjasquad.springmockk.MockkBean
 import com.wafflestudio.account.TestHelper
+import com.wafflestudio.account.api.client.AppleClient
 import com.wafflestudio.account.api.client.KakaoClient
 import com.wafflestudio.account.api.client.OAuth2UserResponse
 import com.wafflestudio.account.api.domain.account.RefreshTokenRepository
@@ -32,6 +33,8 @@ class SocialAuthServiceTest(
 ) {
     @MockkBean
     private lateinit var kakaoClient: KakaoClient
+    @MockkBean
+    private lateinit var appleClient: AppleClient
 
     @AfterEach
     fun afterEach() {


### PR DESCRIPTION
지난 번 11/26 만났던 날 밤에 추가 작업해놓고 이후 변경은 없었습니다.
email 이 안 넘어오는 이슈가 있어서 따로 추가 작업이 필요합니다.

이 PR 을 하게 된 주요한 이유는 우리 서버가 사실 며칠 때 고장나있는 상황이기 때문입니다. (https://argocd.wafflestudio.com/applications/sso-account-server-dev 에서 확인 가능)

원인은 이 작업을 하면서 [SecretsManager](https://ap-northeast-2.console.aws.amazon.com/secretsmanager/secret?name=dev%2Faccount-server&region=ap-northeast-2)에 `spring.security.oauth2.client.registration.apple.*`에 해당하는 걸 넣어놨는데 서버 코드엔 그에 상응하는 provider 가 없어서 서버가 못 뜨게 되었기 때문입니다.

그러면 SecretsManager 에서 해당 값들 빼고 pod 다시 띄우거나 해도 되는데, 차라리 미완이라도 이 PR 을 merge 해놓는 편이 더 발전적이란 생각에 PR 합니다.